### PR TITLE
fix: content-script run_at

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 .DS_Store
+.idea
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ and on your `src/manifest.json`:
 }
 ```
 
+You can change when the content script is executed by changing the value in manifest.json run_at property.
+
+```
+// "document_start", "document_end", "document_idle" */
+
+{
+ "run_at": "document_idle"
+}
+
+```
+
 ## Intelligent Code Completion
 
 Thanks to [@hudidit](https://github.com/lxieyang/chrome-extension-boilerplate-react/issues/4)'s kind suggestions, this boilerplate supports chrome-specific intelligent code completion using [@types/chrome](https://www.npmjs.com/package/@types/chrome). For example:

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,8 @@
   "content_scripts": [{
     "matches": ["http://*/*", "https://*/*", "<all_urls>"],
     "js": ["contentScript.bundle.js"],
-    "css": ["content.styles.css"]
+    "css": ["content.styles.css"],
+    "run_at": "document_start"
   }],
   "web_accessible_resources": [
     "content.styles.css",

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import logo from '../../assets/img/logo.svg';
-import Greetings from '../../containers/Greetings/Greetings';
+// import Greetings from '../../containers/Greetings/Greetings';
 import './Popup.css';
 
 const Popup = () => {


### PR DESCRIPTION
I came across this boilerplate. There was this one issue I saw that the content script wasn't being executed. Also, added the documentation in `README.md`.

PS: Commented out the `Greeting.jsx` container. 