### PR TITLE
WebpackCleanPlugin is unnecessary in Webpack 5, it has built in optio…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@ var webpack = require('webpack'),
   path = require('path'),
   fileSystem = require('fs-extra'),
   env = require('./utils/env'),
-  { CleanWebpackPlugin } = require('clean-webpack-plugin'),
   CopyWebpackPlugin = require('copy-webpack-plugin'),
   HtmlWebpackPlugin = require('html-webpack-plugin'),
   TerserPlugin = require('terser-webpack-plugin');
@@ -51,6 +50,7 @@ var options = {
     path: path.resolve(__dirname, 'build'),
     filename: '[name].bundle.js',
     publicPath: ASSET_PATH,
+    clean: true
   },
   module: {
     rules: [
@@ -109,11 +109,6 @@ var options = {
   },
   plugins: [
     new webpack.ProgressPlugin(),
-    // clean the build folder
-    new CleanWebpackPlugin({
-      verbose: true,
-      cleanStaleWebpackAssets: true,
-    }),
     // expose and write the allowed env vars on the compiled bundle
     new webpack.EnvironmentPlugin(['NODE_ENV']),
     new CopyWebpackPlugin({


### PR DESCRIPTION
Removed WebpackCleanPlugin plugin and added Webpack's option to clean output folder: 
- https://webpack.js.org/guides/output-management/#cleaning-up-the-dist-folder
- https://stackoverflow.com/a/66675975/947111