### PR TITLE
Fixed Prettier Bug

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+# Ignore artifacts:
+build
+coverage
+
+# Ignore all HTML files:
+*.html

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "node utils/build.js",
     "start": "node utils/webserver.js",
-    "prettier": "prettier --write '**/*.{js,jsx,css,html}'"
+    "prettier": "prettier --write **/*.{js,jsx,css,html}"
   },
   "dependencies": {
     "@hot-loader/react-dom": "^17.0.1",


### PR DESCRIPTION
The "prettier" script in package.json gave errors due to some formattting issues.
Also Added .Prettierignore to ignore build/**  and Html files.